### PR TITLE
Add terminal feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ nvim-term
 ==
 Make neovim's `:terminal` useful.
 
+
 Installation
 --
 * To install using dein:
@@ -14,19 +15,29 @@ if = '''has('nvim')'''
 
 Setting
 --
-* Enter terminal, set insert mode. (default 1)
+* Enter terminal, set insert mode. *Default 1*
 ```
 let g:nvimterm#enter_insert = 1
 ```
 
-* Set buffer name of toggle terminal. (default NVIM_TERM)
+* Set buffer name of toggle terminal. *Default NVIM_TERM*
 ```
 let g:nvimterm#toggle_tname = 'NVIM_TERM'
 ```
 
-* Set window size of toggle terminal. (default 15)
+* Set window size of toggle terminal. *Default 15*
 ```
 let g:nvimterm#toggle_size = 15
+```
+
+* Set source directory. *Default script directory* (Run source command, Before open terminal)
+```
+let g:nvimterm#source_dir = '~/'
+```
+
+* Set source file name. *Default .nvimtermrc*
+```
+let g:nvimterm#source_name = '.nvimtermrc'
 ```
 
 

--- a/autoload/.nvimtermrc
+++ b/autoload/.nvimtermrc
@@ -1,0 +1,7 @@
+alias nvim='nvr'
+alias nvimt='nvr -cc tabnew'
+alias nvims='nvr -cc split'
+alias nvimv='nvr -cc vsplit'
+alias nvimT='nvr -cc close && nvr -cc tabnew'
+alias nvimS='nvr -cc close && nvr -cc split'
+alias nvimV='nvr -cc close && nvr -cc vsplit'

--- a/autoload/nvimterm.vim
+++ b/autoload/nvimterm.vim
@@ -3,6 +3,13 @@ let s:enable_keymap = get(g:, 'nvimterm#enable_keymap', 1)
 let s:toggle_tname = get(g:, 'nvimterm#toggle_tname', 'NVIM_TERM')
 let s:toggle_tname = 'term://' . s:toggle_tname
 let s:toggle_size = get(g:, 'nvimterm#toggle_size', 15)
+let s:source_dir = get(g:, 'nvimterm#source_dir', '')
+let s:source_name = get(g:, 'nvimterm#source_name', '.nvimtermrc')
+
+let s:open_source_command = ''
+if s:source_dir == '' && executable('nvr')
+	let s:open_source_command = 'source ' . expand('<sfile>:p:h') . '/' . s:source_name
+endif
 
 function! s:create_buffer(count, newtype) "{{{1
 	let l:newtype = ['new', 'vnew', 'tabnew', 'enew']
@@ -28,7 +35,14 @@ endfunction
 function! nvimterm#open(args, count, newtype) " {{{1
 	call s:create_buffer(a:count, a:newtype)
 
-	exe 'terminal' a:args
+	let id = termopen(&sh)
+	if s:open_source_command != ''
+		call jobsend(id, s:open_source_command . "\<C-m>\<C-l>")
+	endif
+	if a:args != ''
+		call jobsend(id, a:args . "\<C-m>")
+	endif
+	startinsert
 	call s:set_keymap()
 endfunction
 


### PR DESCRIPTION
By setting an alias that nvim overwrite in nvr immediately after opening a terminal, it prevents double booting of neovim